### PR TITLE
Add suppor for hscan do no more errors like  Parameter 2 to Redis::hs…

### DIFF
--- a/src/Blablacar/Redis/Client.php
+++ b/src/Blablacar/Redis/Client.php
@@ -109,4 +109,21 @@ class Client
 
         return call_user_func_array(array($this->redis, $name), $arguments);
     }
+
+    /**
+     * @param string      $key
+     * @param int         $iterator
+     * @param string|null $pattern
+     * @param int         $count
+     *
+     * @return mixed
+     */
+    public function hscan($key, $iterator, $pattern = null, $count = 0)
+    {
+        if (null === $this->redis) {
+            $this->connect();
+        }
+
+        return $this->redis->hscan($key, $iterator, $pattern, $count);
+    }
 }

--- a/src/Blablacar/Redis/Test/Client.php
+++ b/src/Blablacar/Redis/Test/Client.php
@@ -73,7 +73,7 @@ class Client extends BaseClient
     public function hset() {}
     public function hsetnx() {}
     public function hvals() {}
-    public function hscan() {}
+    public function hscan($key, $iterator, $pattern = null, $count = 0) {}
 
     // Lists
     public function blpop() {}


### PR DESCRIPTION
With current implementation we were not able to use hscan due to error:  Parameter 2 to Redis::hscan() expected to be a reference, value given. This PR solves it.