### PR TITLE
Added context in log

### DIFF
--- a/src/Blablacar/Redis/Client.php
+++ b/src/Blablacar/Redis/Client.php
@@ -54,7 +54,11 @@ class Client
         $this->redis = new \Redis();
         $this->redis->connect($this->host, $this->port);
         if (null !== $this->base) {
-            $this->redis->select($this->base);
+            try {
+                $this->redis->select($this->base);
+            } catch (\RedisException $e) {
+                throw new \RedisException(sprintf('%s (%s:%d)', $e->getMessage(), $this->host, $this->port), $e->getCode(), $e);
+            }
         }
     }
 


### PR DESCRIPTION
When having "read error on connection", we do not have the context in the exception. If you work with multiple clients, it's pretty difficult to know which connection is having trouble