### PR TITLE
Add a timeout config parameter

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       matrix:
         php:
-          - 5.4
-          - 5.5
+          - 7.4
+          - 8.0
 
     services:
       redis:

--- a/src/Blablacar/Redis/Client.php
+++ b/src/Blablacar/Redis/Client.php
@@ -6,6 +6,7 @@ class Client
 {
     protected $host;
     protected $port;
+    protected $timeout;
     protected $base;
 
     protected $redis;
@@ -13,16 +14,20 @@ class Client
     /**
      * __construct
      *
+     * By default the timeout value is 0 meaning it will use default_socket_timeout.
+     *
      * @param string $host
      * @param int    $port
+     * @param float  $timeout
      * @param int    $base
      *
      * @return void
      */
-    public function __construct($host = '127.0.0.1', $port = 6379, $base = null)
+    public function __construct($host = '127.0.0.1', $port = 6379, $timeout = 0.0, $base = null)
     {
         $this->host = $host;
         $this->port = $port;
+        $this->timeout = $timeout;
         $this->base = $base;
     }
 
@@ -52,7 +57,7 @@ class Client
         }
 
         $this->redis = new \Redis();
-        $this->redis->connect($this->host, $this->port);
+        $this->redis->connect($this->host, $this->port, $this->timeout);
         if (null !== $this->base) {
             try {
                 $this->redis->select($this->base);


### PR DESCRIPTION
By default, the timeout value is 0 meaning it will use the default_socket_timeout.
The default_socket_timeout value is 60s.

Adding a timeout parameter allows us to configure a proper timeout value on the redis client.